### PR TITLE
Update jest configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     ],
     "setupFiles": [
       "./test/setup.js"
+    ],
+    "collectCoverageFrom": [
+      "src/components/*/index.js"
     ]
   },
   "keywords": [


### PR DESCRIPTION
### What? Why?
- add `collectCoverageFrom`

![image](https://cloud.githubusercontent.com/assets/4191668/19560491/540c5d2a-9707-11e6-9afc-304e6d723293.png)

refs: http://facebook.github.io/jest/docs/configuration.html#collectcoveragefrom-array
### How was it tested?

npm run test

cc @rwu823 @CApopsicle 
