### PR TITLE
Update eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
     'keyword-spacing': ['error', { before: true, after: true }],
     'space-in-parens': ['error', 'never'],
     'space-unary-ops': ['error', { words: true, nonwords: false }],
+    "spaced-comment": [1, "always"],
     'camelcase': ['error', { properties: 'never' }],
     'array-bracket-spacing': ['error', 'never'],
     'semi': ['error', 'never'],

--- a/src/components/checkbox/__test__/checkbox.spec.js
+++ b/src/components/checkbox/__test__/checkbox.spec.js
@@ -87,13 +87,13 @@ it('test Checkbox `non-all` elements affect the `all` element', () => {
     }
   })
 
-  //First Element is clicked
+  // First Element is clicked
   $(vm.$children[1].$el).trigger('click')
   expect(vm.$children[0].check).toBe(false)
   expect(vm.$children[1].check).toBe(false)
   expect(vm.$children[2].check).toBe(true)
 
-  //First Element is clicked again
+  // First Element is clicked again
   $(vm.$children[1].$el).trigger('click')
   expect(vm.$children[0].check).toBe(true)
   expect(vm.$children[1].check).toBe(true)
@@ -139,7 +139,7 @@ it('test <Checkbox> `onChange` props', () => {
     }
   })
 
-  //First Element is clicked
+  // First Element is clicked
   $(vm.$children[0].$el).trigger('click')
 })
 
@@ -159,6 +159,6 @@ it('test <Checkbox.Group> `onChange` props', () => {
     }
   })
 
-  //First Element is clicked
+  // First Element is clicked
   $(vm.$children[1].$el).trigger('click')
 })

--- a/src/components/input/__test__/input.spec.js
+++ b/src/components/input/__test__/input.spec.js
@@ -12,7 +12,7 @@ it('test <Input /> default props', () => {
   expect(vm.icon).toEqual(['grid-4', '#e6175c'])
   expect(vm.status).toBe('normal')
   expect(vm.placeholder).toBe('demo')
-  //clicking on the icon should not empty vm.value
+  // clicking on the icon should not empty vm.value
   $(vm.$children[1].$el).trigger('click')
 })
 
@@ -39,11 +39,11 @@ it('test <Input /> of password mode', () => {
   })
   expect(vm.pwdFill).toBe('#b8bdbf')
   expect(vm.pwdInput).toBe('password')
-  //click on the icon - `eye`
+  // click on the icon - `eye`
   $(vm.$children[1].$el).trigger('click')
   expect(vm.pwdFill).toBe('#8962d9')
   expect(vm.pwdInput).toBe('text')
-  //click on the icon - `eye` again
+  // click on the icon - `eye` again
   $(vm.$children[1].$el).trigger('click')
   expect(vm.pwdFill).toBe('#b8bdbf')
   expect(vm.pwdInput).toBe('password')
@@ -66,7 +66,7 @@ it('test <Input /> with a `x` icon', async() => {
     expect(vm.showX).toBe(true)
     vm.$nextTick(done)
   })
-  //click on the icon - `x`
+  // click on the icon - `x`
   $(vm.$children[1].$el).trigger('click')
   expect(vm.value).toBe('')
 })

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -5,11 +5,11 @@ const Label = {
   props: {
     typ: {
       type: String,
-      default: ''//label, outline, tag
+      default: '' // label, outline, tag
     },
     status: {
       type: String,
-      default: ''//default, primary, success, error, warning, inverted
+      default: '' // default, primary, success, error, warning, inverted
     },
     badge: {
       type: Boolean,

--- a/src/components/tip/__test__/tip.spec.js
+++ b/src/components/tip/__test__/tip.spec.js
@@ -31,9 +31,9 @@ it('test mouse hover event', async() => {
     }
   })
 
-  //when mouse enters
+  // when mouse enters
   $(vm.$el).trigger('mouseenter')
-  //tipContext should show up
+  // tipContext should show up
   const tipContext2 = document.querySelector('#tipContext2')
   expect(getComputedStyle(tipContext2)._values.display).toBe('block')
   await new Promise((done) => {
@@ -42,9 +42,9 @@ it('test mouse hover event', async() => {
     }, 50)
   })
   expect(getComputedStyle(tipContext2)._values.opacity).toBe('1')
-  //when mouse leaves
+  // when mouse leaves
   $(vm.$el).trigger('mouseleave')
-  //tipContext should disappear
+  // tipContext should disappear
   expect(document.querySelector('#tipContext2')).toBe(null)
 })
 


### PR DESCRIPTION
### What? Why?

http://eslint.org/docs/rules/spaced-comment

![image](https://cloud.githubusercontent.com/assets/4191668/20556495/5cf84650-b1a2-11e6-9922-9dbbf50d5f85.png)


- add "spaced-comment": [1, "always"],

### How was it tested?
npm run lint

cc @CApopsicle @rwu823 
