### PR TITLE
[Tab] fix <Tab.Head> without `isSelected` 

### DIFF
--- a/src/components/tab/__test__/tab.spec.js
+++ b/src/components/tab/__test__/tab.spec.js
@@ -1,11 +1,11 @@
 import Tab from '../'
 
-it('test <Tab> with props `name` and `isSelected`', () => {
+it('test <Tab> with props `name` and without props `isSelected`', () => {
   const vm = shallow({
     render(h) {
       return (
         <Tab>
-          <Tab.Head slot="tabHead" name="1" isSelected={true}>Tab1</Tab.Head>
+          <Tab.Head slot="tabHead" name="1">Tab1</Tab.Head>
           <Tab.Head slot="tabHead" name="2">Tab2</Tab.Head>
           <Tab.Content slot="tabContent" name="1">
             <br />Hello, I am tab one
@@ -27,7 +27,7 @@ it('test <Tab> with props `name` and `isSelected`', () => {
   expect(vm.$children[3].isSelected).toBe(false)
 })
 
-it('click on <Tab.Head> to switch <Tab.Content>', async() => {
+it('test <Tab> with props `isSelected` and click on <Tab.Head> to switch <Tab.Content>', async() => {
   let tabData
   const getTabData = (data) => {
     tabData = data

--- a/src/components/tab/index.js
+++ b/src/components/tab/index.js
@@ -13,7 +13,11 @@ const Tab = {
 
   mounted() {//find selected
     const { $slots } = this
-    const selectedChild = $slots.tabHead.find((slot) => slot.child.isSelected)
+    let selectedChild = $slots.tabHead.find((slot) => slot.child.isSelected)
+    if (!selectedChild) {
+      selectedChild = $slots.tabHead[0]
+      $slots.tabHead[0].child.selected = '1'
+    }
     this.selectedIdx = $slots.tabHead.indexOf(selectedChild)
     this.selectedName = selectedChild.child.name
     this.switchContent()

--- a/src/components/tab/tab.scss
+++ b/src/components/tab/tab.scss
@@ -18,4 +18,5 @@
   display: flex;
   font-size: 20px;
   line-height: 26px;
+  border-bottom: 1px solid #dfe4e6;
 }


### PR DESCRIPTION
- add `border-bottom` to `<Tab.Head>`
- 如果`<Tab.Head>` 沒有加 `isSelected` ，預設select第一個

![2016-12-09 11 42 51](https://cloud.githubusercontent.com/assets/5334755/21036969/ddc4f31e-be04-11e6-8f31-91eca34202e4.png)

#80 

cc @rwu823 @chuanxd 