### PR TITLE
Add `margin: 0` to `body` selector

### DIFF
--- a/src/client/app.scss
+++ b/src/client/app.scss
@@ -13,6 +13,7 @@ body {
   color: rgb(57, 57, 57);
   background: #fff;
   overflow-y: scroll;
+  margin: 0;
 }
 
 a {


### PR DESCRIPTION
Add `margin: 0` to `body` selector in app.scss to fix normalize.css v6 issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cepave-f2e/vue-owl-ui/158)
<!-- Reviewable:end -->
