### PR TITLE
Remove * selector by default and get better performance.

### DIFF
--- a/src/client/app.scss
+++ b/src/client/app.scss
@@ -1,14 +1,6 @@
 @import "normalize.css/normalize.css";
 @import "../components/global.scss";
 
-*, *:after, *:before {
-  box-sizing: border-box;
-}
-
-*:after, *:before {
-  content: '';
-}
-
 body {
   font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
   color: rgb(57, 57, 57);

--- a/src/client/components/header/header.scss
+++ b/src/client/components/header/header.scss
@@ -22,7 +22,7 @@ header {
   }
 }
 
-ul {
+.link {
   font-size: 14px;
   display: flex;
   align-items: center;

--- a/src/client/components/header/index.js
+++ b/src/client/components/header/index.js
@@ -21,7 +21,7 @@ const Header = {
               </h1>
             </div>
 
-            <ul>
+            <ul class={[s.link]}>
               <li>
                 <Link to="/">
                   Docs

--- a/src/client/views/components/components.scss
+++ b/src/client/views/components/components.scss
@@ -59,6 +59,9 @@ dd {
     display: block;
     position: relative;
     color: #590aaa;
+    &:after {
+      content: '';
+    }
     &:hover, &:global(.router-link-active) {
       &:after {
         @extend .hover;

--- a/src/client/views/date-picker/doc.md
+++ b/src/client/views/date-picker/doc.md
@@ -48,11 +48,22 @@ defaultValue: {
 ### prev(data)
 
 ### pick(data) 
-- `data.value` Get value of input.
-- `data.year` Get the year.
-- `data.month` Get the month.
-- `data.date` Get the date of month.
-- `data.day` Get the day of week.
-- `data.Date` Get Date instance.
+`data.value` 
+Get value of input.
+
+`data.year` 
+Get the year.
+
+`data.month` 
+Get the month.
+
+`data.date` 
+Get the date of month.
+
+`data.day` 
+Get the day of week.
+
+`data.Date` 
+Get Date instance.
 
 ## Demo

--- a/src/client/views/tab/doc.md
+++ b/src/client/views/tab/doc.md
@@ -34,6 +34,7 @@
 - The sequence of `<Tab.Head>` and `<Tab.Content>` should be placed in order, eg. `1`,`2`,...or `Alarms`, `Alarm History`  
 - Must add attribute `slot="tabHead"` in `<Tab.Head>` and `slot="tabContent"` in `<Tab.Content>`
 - Use `onChange` as a listener to get data from `$emit('change')`
+
 ```jsx
 const getTabData = (data) => {
   console.log(data)

--- a/src/components/complex-query/complex-query.scss
+++ b/src/components/complex-query/complex-query.scss
@@ -163,6 +163,7 @@
 }
 
 .itemCheckbox {
+  box-sizing: border-box;
   width: 100%;
   margin: 0;
   padding: 16px;

--- a/src/components/dual-list/dual-list.scss
+++ b/src/components/dual-list/dual-list.scss
@@ -17,6 +17,7 @@
 .listWrapper {
   padding: 0 10px;
   display: flex;
+  box-sizing: border-box;
   align-items: center;
   height: 40px;
   width: 100%;

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -3,11 +3,12 @@
   min-width: 200px;
 }
 .input {
-  padding: 10px;
+  box-sizing: border-box;
   width: 100%;
   height: 34px;
+  padding: 0 10px;
   font-size: 14px;
-  input-placeholder {
+  &::placeholder {
     color: #b8bdbf;
   }
 }

--- a/src/components/multi-select/multi-select.scss
+++ b/src/components/multi-select/multi-select.scss
@@ -8,11 +8,11 @@ $height: 34px;
 }
 
 .searchField {
+  box-sizing: border-box;
   padding: 5px;
   width: 100%;
   min-height: 46px;
   font-size: 14px;
-  min-height: 46px;
   border: 1px solid #b8bdbf;
   color: #6c7173;
   &:focus, &:active {
@@ -36,6 +36,7 @@ $height: 34px;
 
 .optionBox {
   display: none;
+  box-sizing: border-box;
   width: 100%;
   background-color: #fff;
   border: 1px solid rgba(0, 0, 0, .2);
@@ -47,6 +48,7 @@ $height: 34px;
   top: auto;
   z-index: 1;
   .option {
+    box-sizing: border-box;
     position: relative;
     padding: 6px $pd;
     color: #a0a0a0;
@@ -110,6 +112,7 @@ $height: 34px;
 
 .loadingOption {
   position: relative;
+  box-sizing: border-box;
   width: 100%;
   height: 33px;
   padding: 6px 12px;

--- a/src/components/page/page.scss
+++ b/src/components/page/page.scss
@@ -1,5 +1,3 @@
-//@import "owl-ui-style/dist/owl-ui-style.css";
-
 .page {
   display: flex;
   &[data-align="center"] {
@@ -43,6 +41,7 @@
 
     &.on, &:hover {
       &:before {
+        content: '';
         position: absolute;
         height: 2px;
         bottom: 2px;

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -38,6 +38,7 @@
 }
 
 .defaultSwitch {
+  box-sizing: border-box;
   width: 90px;
   padding: 7px;
   border: 3px solid #b8bdbf;


### PR DESCRIPTION
- 因應 owl-light css reset 移除，組件化的調整
- `*` selector 效能不佳，破壞力太強，請禁用

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cepave-f2e/vue-owl-ui/166)
<!-- Reviewable:end -->
