### PR TITLE
[ComplexQuery] Emit `clickCategory` event and remove the text of total items

### DIFF
--- a/src/client/views/complex-query/doc.md
+++ b/src/client/views/complex-query/doc.md
@@ -62,3 +62,6 @@ Triggerd  by `focus` on input.
 
 ### blur
 Triggerd  by `blur` on input.
+
+### clickCategory
+Triggerd  by `click` a category.

--- a/src/components/complex-query/index.js
+++ b/src/components/complex-query/index.js
@@ -396,7 +396,7 @@ const ComplexQuery = {
               <a onClick={clearAll}>{text.clearAll}</a>
               <a onClick={selectAll}>{text.selectAll}</a>
             </Flex.Col>
-            <Flex.Col>{text.selected}: {sum} / {totalCounts}</Flex.Col>
+            <Flex.Col>{text.selected}: {sum}</Flex.Col>
           </Flex>
         </div>
 

--- a/src/components/complex-query/index.js
+++ b/src/components/complex-query/index.js
@@ -173,13 +173,18 @@ const ComplexQuery = {
         this.$set(items[eq], 'isFold', !items[eq].isFold)
       }
     },
+
     changeCategory(eq) {
-      const { categories } = this
+      const { categories, $refs } = this
 
       return (ev) => {
         categories.forEach((cat, i) => {
           if (i === eq) {
             this.cat = cat.value
+            this.$emit('clickCategory', {
+              value: $refs.query.value,
+              category: cat.value,
+            })
           }
         })
       }


### PR DESCRIPTION
http://jira.cepave.com/browse/OWL-1721
當點擊不同 category 時，觸發 `clickCategory` 事件

http://jira.cepave.com/browse/OWL-1715
移除顯示項目總數

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cepave-f2e/vue-owl-ui/170)
<!-- Reviewable:end -->
